### PR TITLE
feat: configure via command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Readme
+
+## User Guide
+
+## Running the Server
+
+To run the server locally, use the following command:
+
+```bash
+npm run serve --openapi-url="http://localhost:8081/openapi.json"
+```
+
+Alternatively, if the package is installed globally or published to npm, you can run it directly using:
+
+```bash
+npx . --openapi-url="http://localhost:8081/openapi.json"
+```
+

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A MCP server for used with AEP-compliant APIs.",
   "main": "server.ts",
   "type": "module",
+  "bin": "./src/bin.js",
   "scripts": {
     "build": "tsc",
-    "start": "tsc && node dist/server.js",
+    "serve": "tsc && ./src/bin.js",
     "test": "jest"
   },
   "files": [

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// this wrapper is needed to spawn the server with node.
+import { main } from '../dist/server.js';
+main()

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,37 @@
+import { parseArguments } from "./cli.js";
+
+describe("parseArguments", () => {
+    beforeEach(() => {
+        jest.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit called with code ${code}`);
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("should parse required openapiUrl argument", () => {
+        const argv = ["--openapi-url", "http://example.com/openapi.json"];
+        const result = parseArguments(argv);
+        expect(result.openapiUrl).toBe("http://example.com/openapi.json");
+    });
+
+    it("should use default values for optional arguments", () => {
+        const argv = ["--openapi-url", "http://example.com/openapi.json"];
+        const result = parseArguments(argv);
+        expect(result.prefix).toBe("");
+        expect(result.headers).toBe("{}");
+    });
+
+    it("should parse optional arguments when provided", () => {
+        const argv = [
+            "--openapiUrl", "http://example.com/openapi.json",
+            "--prefix", "/api",
+            "--headers", "{\"Authorization\":\"Bearer token\"}"
+        ];
+        const result = parseArguments(argv);
+        expect(result.prefix).toBe("/api");
+        expect(result.headers).toBe("{\"Authorization\":\"Bearer token\"}");
+    });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,23 @@
+import yargs from "yargs";
+
+function parseArguments(args: string[]) {
+    return yargs(args)
+        .option("openapi-url", {
+            type: "string",
+            description: "The URL of the OpenAPI specification",
+            demandOption: true,
+        })
+        .option("prefix", {
+            type: "string",
+            description: "The prefix for API endpoints",
+            default: "",
+        })
+        .option("headers", {
+            type: "string",
+            description: "Custom headers in JSON format",
+            default: "{}",
+        })
+        .parseSync();
+}
+
+export { parseArguments };

--- a/src/common/api/api.test.ts
+++ b/src/common/api/api.test.ts
@@ -2,6 +2,8 @@
 import { API, Contact, OpenAPI, Resource, APISchema } from "./types.js";
 import { APIClient } from "./api.js";
 import { fetchOpenAPI, OpenAPIImpl } from "../openapi/openapi.js";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 const basicOpenAPI: OpenAPI = {
   openapi: "3.1.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,28 +9,14 @@ import axios from "axios";
 import { Client } from "./common/client/client.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { parseArguments } from "./cli.js";
 
+export async function main() {
+  const argv = parseArguments(process.argv.slice(2));
+  const openapiUrl = argv["openapi-url"];
+  const prefix = argv.prefix;
+  const headers: Record<string, string> = JSON.parse(argv.headers);
 
-type RequestHandlerExtra = {
-  [key: string]: unknown;
-};
-
-type ResponseContent = {
-  type: "text";
-  text: string;
-};
-
-type Response = {
-  content: ResponseContent[];
-  _meta?: Record<string, unknown>;
-  isError?: boolean;
-};
-
-const openapiUrl =
-  "https://raw.githubusercontent.com/Roblox/creator-docs/refs/heads/main/content/en-us/reference/cloud/cloud.docs.json";
-const prefix = "/cloud/v2";
-
-async function main() {
   const openapi = await fetchOpenAPI(openapiUrl);
   const oas = new OpenAPIImpl(openapi as OpenAPIType);
 
@@ -47,10 +33,6 @@ async function main() {
       resources: {}
     },
   });
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": process.env.API_KEY!,
-  };
 
   // Create an axios instance with default configuration
   const axiosInstance = axios.create({
@@ -189,5 +171,3 @@ async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }
-
-main();


### PR DESCRIPTION
This will help enable the usage of the aep-mcp-server as a downloadable npm package, rather than a repository that has to be cloned.