### PR TITLE
fix(tools): do not include resource in the tools payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To run the server locally, use the following command:
 
 ```bash
 npm run serve --openapi-url="http://localhost:8081/openapi.json"
+npm run serve --openapi-url="https://raw.githubusercontent.com/Roblox/creator-docs/refs/heads/main/content/en-us/reference/cloud/cloud.docs.json" --prefix="/cloud/v2"
 ```
 
 Alternatively, if the package is installed globally or published to npm, you can run it directly using:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A MCP server for used with AEP-compliant APIs.",
   "main": "server.ts",
   "type": "module",
-  "bin": "./src/bin.js",
+  "bin": "tsc && ./src/bin.js",
   "scripts": {
     "build": "tsc",
     "serve": "tsc && ./src/bin.js",

--- a/src/common/api/api.ts
+++ b/src/common/api/api.ts
@@ -30,7 +30,7 @@ export class APIClient {
         "Unable to detect OAS openapi. Please add an openapi field or a openapi field"
       );
     }
-
+    logger.info(`reading openapi file: ${openAPI.openapi}`);
     const resourceBySingular: Record<string, Resource> = {};
     const customMethodsByPattern: Record<string, CustomMethod[]> = {};
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,6 +10,8 @@ export var logger = winston.createLogger({
     ),
     transports: [
         new winston.transports.Console({
+            // logging to stdout will break the mcp server, so
+            // use stderr instead (which it a better practice anyway)
             stderrLevels: ["error", "warn", "info"],
             debugStdout: false,
         }),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,28 +1,24 @@
 import { Resource, APISchema } from "./common/api/types.js";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
-export interface FullTool extends Tool {
-  resource: Resource;
-}
-
-export function BuildCreateTool(resource: Resource, resourceName: string): FullTool {
+export function BuildCreateTool(resource: Resource, resourceName: string): Tool {
   const schema: {
     type: "object";
     properties: Record<string, unknown>;
     required?: string[];
-  } = { 
+  } = {
     type: "object" as const,
     properties: { ...resource.schema.properties } as Record<string, unknown>
   };
-  
+
   // Process pattern elements
   const patternElems = resource.patternElems.slice(0, -1);
   const required: string[] = [];
 
-  if(schema.required == undefined) {
+  if (schema.required == undefined) {
     schema.required = []
   }
-  
+
   for (const elem of patternElems) {
     if (elem.startsWith('{') && elem.endsWith('}')) {
       const paramName = elem.slice(1, -1);
@@ -34,7 +30,7 @@ export function BuildCreateTool(resource: Resource, resourceName: string): FullT
     }
   }
 
-  if(resource.createMethod?.supportsUserSettableCreate) {
+  if (resource.createMethod?.supportsUserSettableCreate) {
     schema.required.push('id');
     if (schema.properties.id) {
       schema.properties.id = { ...schema.properties.id, readOnly: false };
@@ -48,17 +44,16 @@ export function BuildCreateTool(resource: Resource, resourceName: string): FullT
   return {
     name: `create-${resourceName}`,
     description: `Create a ${resourceName}`,
-    inputSchema: schema,
-    resource: resource,
+    inputSchema: schema
   };
 }
 
-export function BuildDeleteTool(resource: Resource, resourceName: string): FullTool {
+export function BuildDeleteTool(resource: Resource, resourceName: string): Tool {
   const schema: {
     type: "object";
     properties: Record<string, unknown>;
     required?: string[];
-  } = { 
+  } = {
     type: "object" as const,
     properties: {
       path: { type: "string" }
@@ -70,16 +65,15 @@ export function BuildDeleteTool(resource: Resource, resourceName: string): FullT
     name: `delete-${resourceName}`,
     description: `Delete a ${resourceName}`,
     inputSchema: schema,
-    resource: resource,
   };
 }
 
-export function BuildUpdateTool(resource: Resource, resourceName: string): FullTool {
+export function BuildUpdateTool(resource: Resource, resourceName: string): Tool {
   const schema: {
     type: "object";
     properties: Record<string, unknown>;
     required?: string[];
-  } = { 
+  } = {
     type: "object" as const,
     properties: { ...resource.schema.properties } as Record<string, unknown>
   };
@@ -98,7 +92,6 @@ export function BuildUpdateTool(resource: Resource, resourceName: string): FullT
     name: `update-${resourceName}`,
     description: `Update a ${resourceName}`,
     inputSchema: schema,
-    resource: resource,
   };
 }
 


### PR DESCRIPTION
Including the full resources in the tools payload results in an  extremely large resource size, which causes the mcp server response to time out (e.g. with this example from claude-desktop):

```
2025-05-12T05:04:56.699Z [bookstore] [info] Message from client: {"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1,"reason":"Error: MCP error -32001: Request timed out"}}
```

The fix is to remove the resource from the payload, and map the tool to the request another way.